### PR TITLE
Fix space after backslash [sh: command not found]

### DIFF
--- a/bin/metawrap-modules/kraken.sh
+++ b/bin/metawrap-modules/kraken.sh
@@ -123,8 +123,8 @@ for num in "$@"; do
 			# shuffle reads, select top N reads, and then restore tabulation, then
 			# separate reads into F and R files
 			paste $reads_1 $reads_2 | \
-			 awk '{ printf("%s",$0); n++; if(n%4==0) { printf("\n");} else { printf("\t\t");} }' | \ 
-			 shuf | head -n $depth | sed 's/\t\t/\n/g' | \ 
+			 awk '{ printf("%s",$0); n++; if(n%4==0) { printf("\n");} else { printf("\t\t");} }' | \
+			 shuf | head -n $depth | sed 's/\t\t/\n/g' | \
 			 awk -F"\t" '{print $1 > "'"${out}/tmp_1.fastq"'"; print $2 > "'"${out}/tmp_2.fastq"'"}'
 			reads_1=${out}/tmp_1.fastq
 			reads_2=${out}/tmp_2.fastq


### PR DESCRIPTION
The script `kraken.sh` contained spaces after the backslash. This resulted in _command not found_ errors, that prevented the step `metawrap kraken` to finish.