### PR TITLE
Added MDMcleaner and nanopore support for bin_reassembly module

### DIFF
--- a/bin/metawrap-modules/reassemble_bins.sh
+++ b/bin/metawrap-modules/reassemble_bins.sh
@@ -134,7 +134,13 @@ else
 fi
 
 if [ -d ${out}/original_bins ]; then rm -r ${out}/original_bins; fi
-cp -r $bins ${out}/original_bins
+if [ "$mdmcleaner" = true ]; then
+	mkdir ${out}/original_bins
+	for i in $bins/*/*_kept_contigs.fasta.gz; do gunzip -k $i && mv ${i%.gz} ${out}/original_bins; done
+else
+	cp -r $bins ${out}/original_bins
+fi
+
 if [ ! -d ${out}/binned_assembly ]; then mkdir ${out}/binned_assembly; fi
 
 # Clean contig names from MDMcleaner
@@ -174,9 +180,7 @@ if [[ ! -s ${out}/binned_assembly/assembly.fa.amb ]]; then
 	mkdir ${out}/reads_for_reassembly
 
 	comm "Aligning all reads back to entire assembly and splitting reads into individual fastq files based on their bin membership"
-	echo "$nanopore"
-	echo "minimap2 -t $threads -ax map-ont ${out}/binned_assembly/assembly.fa $nanopore_reads | ${SOFT}/filter_nanopore_reads_for_bin_reassembly.py ${out}/original_bins ${out}/reads_for_reassembly"
-	if [ "$nanopore" = true ]; then
+		if [ "$nanopore" = true ]; then
 		minimap2 -t $threads -ax map-ont ${out}/binned_assembly/assembly.fa $nanopore_reads \
 		| ${SOFT}/filter_nanopore_reads_for_bin_reassembly.py ${out}/original_bins ${out}/reads_for_reassembly
 	fi

--- a/bin/metawrap-modules/reassemble_bins.sh
+++ b/bin/metawrap-modules/reassemble_bins.sh
@@ -21,6 +21,8 @@ help_message () {
 	echo "	-1 STR          forward reads to use for reassembly"
 	echo "	-2 STR          reverse reads to use for reassembly"
 	echo ""
+	echo "	--nanopore STR	nanopore reads to use for reassembly"
+	echo ""
 	echo "	-t INT		number of threads (default=1)"
 	echo "	-m INT		memory in GB (default=40)"
 	echo "	-c INT		minimum desired bin completion % (default=70)"
@@ -31,8 +33,7 @@ help_message () {
 	echo "	--permissive-cut-off	maximum allowed SNPs for permissive read mapping (default=5)"
 	echo "	--skip-checkm		dont run CheckM to assess bins"
 	echo "	--parallel		run spades reassembly in parallel, but only using 1 thread per bin"
-	echo "	--nanopore		add nanopore reads for reassembly"
-	echo "	--mdmcleaner	pass this flag if data was previously cleaned with MDMcleaner to fix contig names"
+	echo "	--mdmcleaner		the bin directory have results from MDMcleaner"
 	echo "";}
 
 comm () { ${SOFT}/print_comment.py "$1" "-"; }

--- a/bin/metawrap-scripts/filter_nanopore_reads_for_bin_reassembly.py
+++ b/bin/metawrap-scripts/filter_nanopore_reads_for_bin_reassembly.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python2.7
+import sys, os
+
+complement = {'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A', 'a':'t', 't':'a', 'c':'g', 'g':'c', 'N':'N', 'n':'n', '*':'*'} 
+def rev_comp(seq):
+	rev_comp=""
+	for n in seq:
+		rev_comp+=complement[n]
+	return rev_comp[::-1]
+
+# load bin contigs
+print "loading contig to bin mappings..."
+contig_bins={}
+for bin_file in os.listdir(sys.argv[1]):
+	if bin_file.endswith(".fa") or bin_file.endswith(".fasta"): 
+		bin_name=".".join(bin_file.split("/")[-1].split(".")[:-1])
+		for line in open(sys.argv[1]+"/"+bin_file):
+			if line[0]!=">": continue
+			contig_bins[line[1:-1]]=bin_name
+
+# store the read names and what bins they belong in in these dictionaries
+# strict stores only perfectly aligning reads and permissive stores any aligned reads
+
+print "Parsing sam file and writing reads to appropriate files depending what bin they alligned to..."
+files={}
+opened_bins={}
+for line in sys.stdin:
+	if line[0]=="@": continue
+	cut = line.strip().split("\t")
+	binary_flag = bin(int(cut[1]))
+
+	# skip non aligned reads
+	if cut[2]=="*": continue
+
+	# make sure the R and F reads aligned to the same bin
+	if cut[2] not in contig_bins: continue
+
+	# make sure the reads aligned again
+	if "NM:i:" not in line: continue
+
+	bin_name = contig_bins[cut[2]]
+	# open the revelant output files
+	if bin_name not in opened_bins:
+		opened_bins[bin_name]=None
+		files[sys.argv[2]+"/"+bin_name+".nanopore.fastq"]=open(sys.argv[2]+"/"+bin_name+".nanopore.fastq", "w")
+
+	# determine alignment type from bitwise FLAG
+	binary_flag = bin(int(cut[1]))
+
+	# if the reads are reversed, fix them
+	try:
+		if binary_flag[-5]=='1':
+			cut[9] = rev_comp(cut[9])
+			cut[10] = cut[10][::-1]
+	except IndexError:
+		pass
+
+
+	# strict assembly
+	files[sys.argv[2]+"/"+bin_name+".nanopore.fastq"].write('@' + cut[0] + "/1" + "\n" + cut[9] + "\n+\n" + cut[10] + "\n")
+
+
+print "closing files"
+for f in files:
+	files[f].close()
+
+
+print "Finished splitting reads!"


### PR DESCRIPTION
- Added boolean flag `--mdmcleaner`, which then make the reassembly module parse the output of bin filtering after MDMcleaner. See MDMcleaner [here](https://github.com/KIT-IBG-5/mdmcleaner)
- Added `--nanopore` flag. Reads are aligned with minimap2, splited into bins and then are supplied with `--nanopore` flag to spades for both: strict and permissive assemblies. 